### PR TITLE
feat: time ordered consumers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "redis-stream"
-version = "0.1.3-a"
 authors = ["Jean-Paul Bonnetouche <dev@klaxit.com>"]
-keywords = ["redis", "database", "stream", "consumer-groups"]
 description = "Stream and consume data from redis streams."
-homepage = "https://github.com/klaxit/redis-stream-rs"
-repository = "https://github.com/klaxit/redis-stream-rs"
 documentation = "https://docs.rs/redis-stream"
-license = "MIT"
-readme = "README.md"
 edition = "2018"
+homepage = "https://github.com/klaxit/redis-stream-rs"
 include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
+keywords = ["redis", "database", "stream", "consumer-groups"]
+license = "MIT"
+name = "redis-stream"
+readme = "README.md"
+repository = "https://github.com/klaxit/redis-stream-rs"
+version = "0.1.3-a"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,3 +21,7 @@ redis = "0.20.0"
 [dev-dependencies]
 rand = "0.8"
 regex = "1.4.1"
+
+[features]
+# time ordered consumers
+tocs = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-stream"
-version = "0.1.2"
+version = "0.1.3-a"
 authors = ["Jean-Paul Bonnetouche <dev@klaxit.com>"]
 keywords = ["redis", "database", "stream", "consumer-groups"]
 description = "Stream and consume data from redis streams."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@ use anyhow::{Context, Result};
 use redis::{Commands, Connection};
 
 pub mod consumer;
+#[cfg(feature = "tocs")]
+pub mod time_ordered_consumers;
 pub mod types;
 
 /// Produces a new message into a Redis stream.

--- a/src/time_ordered_consumers.rs
+++ b/src/time_ordered_consumers.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "tocs")]
+use crate::consumer::*;

--- a/src/time_ordered_consumers.rs
+++ b/src/time_ordered_consumers.rs
@@ -1,10 +1,15 @@
-#[cfg(feature = "tocs")]
 use crate::consumer::*;
+use anyhow::{Context, Result};
 
 pub struct TimeOrderedConsumers {
   consumers: Vec<Consumer>,
 }
 
 impl TimeOrderedConsumers {
-  fn consume(&self) {}
+  fn consume(&self) -> Result<()> {
+    todo!("sort by xid");
+    todo!("copy paste a bunch from consumer.consume");
+    todo!("call something like consumer.process_message... BUT");
+    todo!("xack a bunch of things at once to reduce calls? maybe?")
+  }
 }

--- a/src/time_ordered_consumers.rs
+++ b/src/time_ordered_consumers.rs
@@ -1,2 +1,10 @@
 #[cfg(feature = "tocs")]
 use crate::consumer::*;
+
+pub struct TimeOrderedConsumers {
+  consumers: Vec<Consumer>,
+}
+
+impl TimeOrderedConsumers {
+  fn consume(&self) {}
+}


### PR DESCRIPTION
# TODOs

- [ ] think about `XREADGROUP` vs `XREAD` 
- [ ] remove unnecessary Cargo.toml reformatting